### PR TITLE
Use jar shading and load scopes from config

### DIFF
--- a/GoogleGroupConnector/pom.xml
+++ b/GoogleGroupConnector/pom.xml
@@ -35,17 +35,17 @@
 		<dependency>
 			<groupId>com.google.apis</groupId>
 			<artifactId>google-api-services-admin-directory</artifactId>
-			<version>directory_v1-rev54-1.20.0</version>
+			<version>directory_v1-rev80-1.22.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.http-client</groupId>
 			<artifactId>google-http-client-jackson2</artifactId>
-			<version>1.18.0-rc</version>
+			<version>1.22.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.api-client</groupId>
 			<artifactId>google-api-client</artifactId>
-			<version>1.18.0-rc</version>
+			<version>1.22.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.opencsv</groupId>

--- a/GoogleGroupConnector/pom.xml
+++ b/GoogleGroupConnector/pom.xml
@@ -3,7 +3,7 @@
 
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>cz.metacentrum.perun</groupId>
+	<groupId>cz.metacentrum.perun.core</groupId>
 	<artifactId>GoogleGroupConnector</artifactId>
 	<version>1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
@@ -12,7 +12,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<start-class>cz.metacentrum.perun.core.googlegroupconnector.GoogleGroupsService</start-class>
+		<start-class>cz.metacentrum.perun.core.googlegroupconnector.GoogleGroupsServiceImpl</start-class>
 	</properties>
 
 	<build>

--- a/GoogleGroupConnector/pom.xml
+++ b/GoogleGroupConnector/pom.xml
@@ -1,33 +1,70 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
 	<modelVersion>4.0.0</modelVersion>
+
 	<groupId>cz.metacentrum.perun</groupId>
 	<artifactId>GoogleGroupConnector</artifactId>
 	<version>1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
+
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
+		<start-class>cz.metacentrum.perun.core.googlegroupconnector.GoogleGroupsService</start-class>
 	</properties>
 
 	<build>
 		<plugins>
+
 			<plugin>
 				<!-- Build an executable JAR -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.4</version>
+			</plugin>
+
+			<!-- Package JAR with Main class and all libraries -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
 				<configuration>
-					<archive>
-						<manifest>
-							<addClasspath>true</addClasspath>
-							<classpathPrefix>lib/</classpathPrefix>
-							<mainClass>cz.metacentrum.perun.core.googlegroupconnector.GoogleGroupsService</mainClass>
-						</manifest>
-					</archive>
+					<createDependencyReducedPom>false</createDependencyReducedPom>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>${start-class}</mainClass>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- Executing plug-in:  mvn exec:java -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>java</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<mainClass>${start-class}</mainClass>
 				</configuration>
 			</plugin>
+
 		</plugins>
 	</build>
 

--- a/GoogleGroupConnector/src/main/java/cz/metacentrum/perun/core/googlegroupconnector/GoogleGroupsConnectionImpl.java
+++ b/GoogleGroupConnector/src/main/java/cz/metacentrum/perun/core/googlegroupconnector/GoogleGroupsConnectionImpl.java
@@ -7,7 +7,6 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.json.JsonFactory;
 
-import com.google.api.services.admin.directory.DirectoryScopes;
 import com.google.api.services.admin.directory.Directory;
 
 import java.io.FileInputStream;
@@ -101,10 +100,7 @@ public class GoogleGroupsConnectionImpl implements GoogleGroupsConnection {
 			GoogleGroupsConnectionImpl.SERVICE_ACCOUNT_PKCS12_FILE_PATH = prop.getProperty("service_account_pkcs12_file_path");
 			GoogleGroupsConnectionImpl.JSON_FACTORY = JacksonFactory.getDefaultInstance();
 			GoogleGroupsConnectionImpl.HTTP_TRANSPORT = GoogleNetHttpTransport.newTrustedTransport();
-			GoogleGroupsConnectionImpl.SCOPES = Arrays.asList(DirectoryScopes.ADMIN_DIRECTORY_USER,
-					DirectoryScopes.ADMIN_DIRECTORY_USER_READONLY,
-					DirectoryScopes.ADMIN_DIRECTORY_GROUP,
-					DirectoryScopes.ADMIN_DIRECTORY_GROUP_MEMBER);
+			GoogleGroupsConnectionImpl.SCOPES = Arrays.asList(prop.getProperty("scopes").split(","));
 
 		} catch (IOException ex) {
 			String msg = "Problem with I/O operation while reading google_groups.properties file.";


### PR DESCRIPTION
- Shade all dependencies to single jar, do not use lib/ folder.
- Move project to perun.core package instead of perun.
- Update GoogleApis dependencies.
- Load list of scopes from config file instead of hardcoded list.